### PR TITLE
Set the Payment state last

### DIFF
--- a/controllers/front/orderManager.php
+++ b/controllers/front/orderManager.php
@@ -96,15 +96,11 @@ class DnapaymentsOrderManagerModuleFrontController extends ModuleFrontController
                 // to fix error with localization
                 Context::getContext()->currency = Context::getContext()->currency ?? new Currency((int)$order->id_currency);
 
-                $state = (int)Configuration::get('PS_OS_PAYMENT');
-                $order->setCurrentState($state);
-
                 $id_order_payment = (int) Db::getInstance()->getValue(
                     'SELECT `id_order_payment`
                     FROM `' . _DB_PREFIX_ . 'order_invoice_payment`
                     WHERE `id_order` =  ' . $order->id
                 );
-
 
                 if ($id_order_payment) {
                     Db::getInstance()->execute(
@@ -117,6 +113,9 @@ class DnapaymentsOrderManagerModuleFrontController extends ModuleFrontController
                         WHERE  `id_order_payment` = '.$id_order_payment
                     );
                 }
+               
+                $state = (int)Configuration::get('PS_OS_PAYMENT');
+                $order->setCurrentState($state);
 
                 echo $input['invoiceId'];
                 return;


### PR DESCRIPTION
The payment state function calls multiple sub functions with multiple hooks. We had an issue storing transaction details and payment state because another plugin (TrustPilot) was turning off error reporting and spitting a 500 error on the OrderHistory function. Doing it like this means we always capture the transaction details.